### PR TITLE
Add `SlangResult` helper functions

### DIFF
--- a/generate.jai
+++ b/generate.jai
@@ -40,6 +40,8 @@ generate_bindings :: () -> bool {
 
         generate_library_declarations=false;
         visitor=slang_visitor;
+
+        header = SLANG_RESULT_HELPERS;
     }
 
     return generate_bindings(opts, output_filename);
@@ -63,3 +65,59 @@ slang_visitor :: (decl: *Declaration, parent_decl: *Declaration) -> result: Decl
 #import "Compiler";
 #import "File";
 #import "String";
+
+SLANG_RESULT_HELPERS :: #string __slang_header
+
+// Slang Result helpers and macro-defined constants
+
+SLANG_FAILED :: (status: s32) -> bool {
+    return status < 0;
+}
+
+SLANG_SUCCEEDED :: (status: s32) -> bool {
+    return status >= 0;
+}
+
+SLANG_GET_RESULT_FACILITY :: (r: s32) -> s32 {
+    return (r >> 16) & 0x7fff;
+}
+
+SLANG_GET_RESULT_CODE :: (r: s32) -> s32 {
+    return r & 0xffff;
+}
+
+SLANG_MAKE_ERROR :: (fac: s32, code: s32) -> s32 {
+    return (fac << 16) | code | cast(s32, 0x80000000);
+}
+
+SLANG_MAKE_SUCCESS :: (fac: s32, code: s32) -> s32 {
+    return (fac << 16) | cast(s32, code);
+}
+
+SLANG_FAIL :: #run SLANG_MAKE_ERROR(SLANG_FACILITY_WIN_GENERAL, 0x4005);
+
+SLANG_MAKE_WIN_GENERAL_ERROR :: (code: s32) -> s32 {
+    return SLANG_MAKE_ERROR(SLANG_FACILITY_WIN_GENERAL, code);
+}
+
+SLANG_E_NOT_IMPLEMENTED :: #run SLANG_MAKE_WIN_GENERAL_ERROR(0x4001);
+SLANG_E_NO_INTERFACE    :: #run SLANG_MAKE_WIN_GENERAL_ERROR(0x4002);
+SLANG_E_ABORT           :: #run SLANG_MAKE_WIN_GENERAL_ERROR(0x4004);
+
+SLANG_E_INVALID_HANDLE :: #run SLANG_MAKE_ERROR(SLANG_FACILITY_WIN_API, 6);
+SLANG_E_INVALID_ARG    :: #run SLANG_MAKE_ERROR(SLANG_FACILITY_WIN_API, 0x57);
+SLANG_E_OUT_OF_MEMORY  :: #run SLANG_MAKE_ERROR(SLANG_FACILITY_WIN_API, 0xe);
+
+SLANG_MAKE_CORE_ERROR :: (code: s32) -> s32 {
+    return SLANG_MAKE_ERROR(SLANG_FACILITY_CORE, code);
+}
+
+SLANG_E_BUFFER_TOO_SMALL :: #run SLANG_MAKE_CORE_ERROR(1);
+SLANG_E_UNINITIALIZED    :: #run SLANG_MAKE_CORE_ERROR(2);
+SLANG_E_PENDING          :: #run SLANG_MAKE_CORE_ERROR(3);
+SLANG_E_CANNOT_OPEN      :: #run SLANG_MAKE_CORE_ERROR(4);
+SLANG_E_NOT_FOUND        :: #run SLANG_MAKE_CORE_ERROR(5);
+SLANG_E_INTERNAL_FAIL    :: #run SLANG_MAKE_CORE_ERROR(6);
+SLANG_E_NOT_AVAILABLE    :: #run SLANG_MAKE_CORE_ERROR(7);
+SLANG_E_TIME_OUT         :: #run SLANG_MAKE_CORE_ERROR(8);
+__slang_header;

--- a/windows.jai
+++ b/windows.jai
@@ -4,6 +4,59 @@
 // jai generate.jai
 //
 
+// Slang Result helpers and macro-defined constants
+
+SLANG_FAILED :: (status: s32) -> bool {
+    return status < 0;
+}
+
+SLANG_SUCCEEDED :: (status: s32) -> bool {
+    return status >= 0;
+}
+
+SLANG_GET_RESULT_FACILITY :: (r: s32) -> s32 {
+    return (r >> 16) & 0x7fff;
+}
+
+SLANG_GET_RESULT_CODE :: (r: s32) -> s32 {
+    return r & 0xffff;
+}
+
+SLANG_MAKE_ERROR :: (fac: s32, code: s32) -> s32 {
+    return (fac << 16) | code | cast(s32, 0x80000000);
+}
+
+SLANG_MAKE_SUCCESS :: (fac: s32, code: s32) -> s32 {
+    return (fac << 16) | cast(s32, code);
+}
+
+SLANG_FAIL :: #run SLANG_MAKE_ERROR(SLANG_FACILITY_WIN_GENERAL, 0x4005);
+
+SLANG_MAKE_WIN_GENERAL_ERROR :: (code: s32) -> s32 {
+    return SLANG_MAKE_ERROR(SLANG_FACILITY_WIN_GENERAL, code);
+}
+
+SLANG_E_NOT_IMPLEMENTED :: #run SLANG_MAKE_WIN_GENERAL_ERROR(0x4001);
+SLANG_E_NO_INTERFACE    :: #run SLANG_MAKE_WIN_GENERAL_ERROR(0x4002);
+SLANG_E_ABORT           :: #run SLANG_MAKE_WIN_GENERAL_ERROR(0x4004);
+
+SLANG_E_INVALID_HANDLE :: #run SLANG_MAKE_ERROR(SLANG_FACILITY_WIN_API, 6);
+SLANG_E_INVALID_ARG    :: #run SLANG_MAKE_ERROR(SLANG_FACILITY_WIN_API, 0x57);
+SLANG_E_OUT_OF_MEMORY  :: #run SLANG_MAKE_ERROR(SLANG_FACILITY_WIN_API, 0xe);
+
+SLANG_MAKE_CORE_ERROR :: (code: s32) -> s32 {
+    return SLANG_MAKE_ERROR(SLANG_FACILITY_CORE, code);
+}
+
+SLANG_E_BUFFER_TOO_SMALL :: #run SLANG_MAKE_CORE_ERROR(1);
+SLANG_E_UNINITIALIZED    :: #run SLANG_MAKE_CORE_ERROR(2);
+SLANG_E_PENDING          :: #run SLANG_MAKE_CORE_ERROR(3);
+SLANG_E_CANNOT_OPEN      :: #run SLANG_MAKE_CORE_ERROR(4);
+SLANG_E_NOT_FOUND        :: #run SLANG_MAKE_CORE_ERROR(5);
+SLANG_E_INTERNAL_FAIL    :: #run SLANG_MAKE_CORE_ERROR(6);
+SLANG_E_NOT_AVAILABLE    :: #run SLANG_MAKE_CORE_ERROR(7);
+SLANG_E_TIME_OUT         :: #run SLANG_MAKE_CORE_ERROR(8);
+
 
 
 SLANG_VC :: 14;


### PR DESCRIPTION
Hi, thanks for making these bindings!

This re-adds the `SLANG_*` result macros that are useful for checking/diagnosing a `SlangResult`, and adding back missing defines that get stripped out.

For example, a function to check the result:
```odin
slang_check :: (result: Slang.SlangResult, loc := #caller_location) {
    code := Slang.SLANG_GET_RESULT_CODE(result);
    facility := Slang.SLANG_GET_RESULT_FACILITY(result);
    
    assert(Slang.SLANG_SUCCEEDED(result), "Slang failed: %, Facility (%)", code, facility, loc = loc);
}
```